### PR TITLE
Introducing an aux paramter to control the computation of ISS

### DIFF
--- a/src/main/java/optimizer/Definitions.java
+++ b/src/main/java/optimizer/Definitions.java
@@ -158,6 +158,7 @@ public class Definitions {
    public static final String SCENARIOS_PATH = "scenarios";
    public static final String LINK_CAPACITY_TYPES = "link_capacity_types";
    public static final String SERVER_CAPACITY_TYPES = "server_capacity_types";
+   public static final String COMPUTE_ISS = "compute_iss";
 
    // GUI parameters
    public static final String NODE_COLOR = "Black";
@@ -189,7 +190,4 @@ public class Definitions {
    public static final String ERROR = "ERROR - ";
    public static final String INFO = "INFO - ";
    public static final String WARNING = "WARN - ";
-
-   // Software and optimizer general parameters
-   public static final boolean COMPUTE_ISS = false;
 }

--- a/src/main/java/optimizer/Parameters.java
+++ b/src/main/java/optimizer/Parameters.java
@@ -88,6 +88,10 @@ public class Parameters {
       boolean allNodesToCloud = false;
       if (global.containsKey(ALL_NODES_TO_CLOUD))
          allNodesToCloud = (boolean) global.get(ALL_NODES_TO_CLOUD);
+      // Always compute ISS unless "compute_iss" is set to false in the yml file
+      if (!global.containsKey(COMPUTE_ISS)){
+         global.put(COMPUTE_ISS, true);
+      }
       graph = GraphManager.importTopology(topologyFile, directedEdges, allNodesToCloud);
       paths = GraphManager.importPaths(graph, pathsFile);
       try {

--- a/src/main/java/optimizer/lp/ModelLP.java
+++ b/src/main/java/optimizer/lp/ModelLP.java
@@ -201,7 +201,7 @@ public class ModelLP {
          double objValLog = Auxiliary.roundDouble(objVal, 4);
          printLog(log, INFO, "finished [" + objValLog + "]");
          return objVal;
-      } else if (grbModel.get(GRB.IntAttr.Status) == GRB.Status.INFEASIBLE && COMPUTE_ISS) {
+      } else if (grbModel.get(GRB.IntAttr.Status) == GRB.Status.INFEASIBLE && (Boolean)pm.getGlobal().get(COMPUTE_ISS)) {
          grbModel.computeIIS();
          printISS();
          printLog(log, ERROR, "model is infeasible");


### PR DESCRIPTION
A new parameter was introduced in the `.yml` file in the `aux` section to control the computation of the ISS when the model is infeasible. 
When this parameter is absent, its value is always assumed as `true`  which means, the ISS is computed and presented to the user. One could want to speed up the experiments by making the parameter `compute_iss: false` in the aux section.

Ex:
```yml
aux: {
    ...
    compute_iss: false,
    ....
}
```
