### PR TITLE
Decomposing force-src-dst into two constraints

### DIFF
--- a/src/main/java/optimizer/Definitions.java
+++ b/src/main/java/optimizer/Definitions.java
@@ -95,7 +95,8 @@ public class Definitions {
    public static final String PATHS_SERVERS_CLOUD = "paths_servers_cloud";
 
    // other constraints
-   public static final String FORCE_SRC_DST = "force_src_dst";
+   public static final String FORCE_SRC = "force_src";
+   public static final String FORCE_DST = "force_dst";
    public static final String CONST_REP = "const_rep";
 
    // service parameters

--- a/src/main/java/optimizer/lp/SpecificConstraints.java
+++ b/src/main/java/optimizer/lp/SpecificConstraints.java
@@ -70,8 +70,10 @@ public class SpecificConstraints {
             singlePath();
          if (sc.getConstraints().get(SET_INIT_PLC))
             setInitPlc(initialPlacement);
-         if (sc.getConstraints().get(FORCE_SRC_DST))
-            forceSrcDst();
+         if (sc.getConstraints().get(FORCE_SRC))
+            forceSrc();
+         if (sc.getConstraints().get(FORCE_DST))
+            forceDst();
          if (sc.getConstraints().get(CONST_REP))
             constRep();
          if (sc.getConstraints().containsKey(PATHS_SERVERS_CLOUD))
@@ -553,21 +555,29 @@ public class SpecificConstraints {
    }
 
    // Fix src-dst functions
-   private void forceSrcDst() throws GRBException {
+   private void forceSrc() throws GRBException {
       for (int s = 0; s < pm.getServices().size(); s++) {
          Path path = pm.getServices().get(s).getTrafficFlow().getPaths().get(0);
          Node srcNode = path.getNodePath().get(0);
-         Node dstNode = path.getNodePath().get(path.getNodePath().size() - 1);
          GRBLinExpr exprSrc = new GRBLinExpr();
-         GRBLinExpr exprDst = new GRBLinExpr();
          for (int x = 0; x < pm.getServers().size(); x++) {
             if (pm.getServers().get(x).getParent().getId().equals(srcNode.getId()))
                exprSrc.addTerm(1.0, vars.fXSV[x][s][0]);
+         }
+         modelLP.getGrbModel().addConstr(exprSrc, GRB.EQUAL, 1.0, FORCE_SRC);
+      }
+   }
+
+   private void forceDst() throws GRBException {
+      for (int s = 0; s < pm.getServices().size(); s++) {
+         Path path = pm.getServices().get(s).getTrafficFlow().getPaths().get(0);
+         Node dstNode = path.getNodePath().get(path.getNodePath().size() - 1);
+         GRBLinExpr exprDst = new GRBLinExpr();
+         for (int x = 0; x < pm.getServers().size(); x++) {
             if (pm.getServers().get(x).getParent().getId().equals(dstNode.getId()))
                exprDst.addTerm(1.0, vars.fXSV[x][s][pm.getServices().get(s).getFunctions().size() - 1]);
          }
-         modelLP.getGrbModel().addConstr(exprSrc, GRB.EQUAL, 1.0, FORCE_SRC_DST);
-         modelLP.getGrbModel().addConstr(exprDst, GRB.EQUAL, 1.0, FORCE_SRC_DST);
+         modelLP.getGrbModel().addConstr(exprDst, GRB.EQUAL, 1.0, FORCE_DST);
       }
    }
 

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -150,8 +150,12 @@
                                 <span class="checkmark"></span>
                             </label>
                             <label>Other</label>
-                            <label class="check ">force-src-dst
-                                <input type="checkbox" id="force-src-dst">
+                            <label class="check ">force-src
+                                <input type="checkbox" id="force-src">
+                                <span class="checkmark"></span>
+                            </label>
+                            <label class="check ">force-dst
+                                <input type="checkbox" id="force-dst">
                                 <span class="checkmark"></span>
                             </label>
                             <label class="check ">const-rep

--- a/src/main/resources/public/static/js/form.js
+++ b/src/main/resources/public/static/js/form.js
@@ -162,7 +162,8 @@ function generateScenario() {
     var single_path = $("#single-path").is(":checked");
     var set_init_plc = $("#set-init-plc").is(":checked");
     // other
-    var force_src_dst = $("#force-src-dst").is(":checked");
+    var force_src = $("#force-src").is(":checked");
+    var force_dst = $("#force-dst").is(":checked");
     var const_rep = $("#const-rep").is(":checked");
     var scenario = JSON.stringify({
         inputFileName: inputFileName,
@@ -187,10 +188,10 @@ function generateScenario() {
             single_path: single_path,
             set_init_plc: set_init_plc,
             // other
-            force_src_dst: force_src_dst,
+            force_src: force_src,
+            force_dst: force_dst,
             const_rep: const_rep
         }
     });
     return scenario;
 }
-


### PR DESCRIPTION
Now the "force-source" and "force-destination" can be enabled independently, allowing the user to choose whether to place the first VNF in the first node of the path, the last VNF on the last node of the path of both.
A new control in the interface was introduced.